### PR TITLE
データの軽量化と処理落ち対策

### DIFF
--- a/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/FaceAnimationRecorder.cs
+++ b/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/FaceAnimationRecorder.cs
@@ -286,30 +286,10 @@ namespace Entum
                     float pastBlendshapeWeight = -1;
                     for (int k = 0; k < _facialData.Facials.Count; k++)
                     {
-                        float time = 0;
-                        if (k > 0)
-                        {
-                            time = facial.Facials[k - 1].Time;
-                        }
-
-                        for (float ind = time; ind < facial.Facials[k].Time; ind += 0.1f)
-                        {
-                            if (k > 0)
-                            {
-                                curve.AddKey(ind,
-                                    _facialData.Facials[k - 1].Smeshes[faceTargetMeshIndex]
-                                        .blendShapes[blendShapeIndex]);
-                            }
-                            else
-                            {
-                                curve.AddKey(ind,
-                                    _facialData.Facials[0].Smeshes[faceTargetMeshIndex].blendShapes[blendShapeIndex]);
-                            }
-                        }
-
-                        curve.AddKey(facial.Facials[k].Time,
-                            _facialData.Facials[k].Smeshes[faceTargetMeshIndex].blendShapes[blendShapeIndex]);
-
+                        if (!(Mathf.Abs(pastBlendshapeWeight - _facialData.Facials[k].Smeshes[faceTargetMeshIndex].blendShapes[blendShapeIndex]) >
+                              0.1f)) continue;
+                        curve.AddKey(new Keyframe(facial.Facials[k].Time, _facialData.Facials[k].Smeshes[faceTargetMeshIndex].blendShapes[blendShapeIndex], float.PositiveInfinity, 0f));
+                        pastBlendshapeWeight = _facialData.Facials[k].Smeshes[faceTargetMeshIndex].blendShapes[blendShapeIndex];
                     }
 
 

--- a/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/FaceAnimationRecorder.cs
+++ b/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/FaceAnimationRecorder.cs
@@ -46,6 +46,7 @@ namespace Entum
         CharacterFacialData.SerializeHumanoidFace _past = new CharacterFacialData.SerializeHumanoidFace();
 
         private float _recordedTime = 0f;
+        private float _startTime;
 
         // Use this for initialization
         private void OnEnable()
@@ -114,6 +115,7 @@ namespace Entum
             Debug.Log("FaceAnimationRecorder record start");
             _recording = true;
             _recordedTime = 0f;
+            _startTime = Time.time;
             _frameCount = 0;
             _facialData = ScriptableObject.CreateInstance<CharacterFacialData>();
         }
@@ -166,7 +168,7 @@ namespace Entum
                 AssetDatabase.CreateAsset(_facialData, path);
                 AssetDatabase.Refresh();
             }
-
+            _startTime = Time.time;
             _recordedTime = 0f;
             _frameCount = 0;
         }
@@ -200,7 +202,7 @@ namespace Entum
                 return;
             }
 
-            _recordedTime += Time.deltaTime;
+            _recordedTime = Time.time - _startTime;
 
             var p = new CharacterFacialData.SerializeHumanoidFace();
             for (int i = 0; i < _smeshs.Length; i++)

--- a/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/FaceAnimationRecorder.cs
+++ b/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/FaceAnimationRecorder.cs
@@ -31,6 +31,9 @@ namespace Entum
         [Header("リップシンクを記録したくない場合はここにモーフ名を入れていく 例:face_mouse_eなど")] [SerializeField]
         private List<string> _exclusiveBlendshapeNames;
 
+        [Tooltip("記録するFPS。0で制限しない。UpdateのFPSは超えられません。")]
+        public float TargetFPS = 60.0f;
+
         private MotionDataRecorder _animRecorder;
 
 
@@ -203,6 +206,27 @@ namespace Entum
             }
 
             _recordedTime = Time.time - _startTime;
+
+            if (TargetFPS != 0.0f)
+            {
+                var nextTime = (1.0f * (_frameCount + 1)) / TargetFPS;
+                if (nextTime > _recordedTime)
+                {
+                    return;
+                }
+                if (_frameCount % TargetFPS == 0)
+                {
+                    print("Face_FPS=" + 1 / (_recordedTime / _frameCount));
+                }
+            }
+            else
+            {
+                if (Time.frameCount % Application.targetFrameRate == 0)
+                {
+                    print("Face_FPS=" + 1 / Time.deltaTime);
+                }
+            }
+
 
             var p = new CharacterFacialData.SerializeHumanoidFace();
             for (int i = 0; i < _smeshs.Length; i++)

--- a/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/ForRuntime/MotionDataRecorderCSV.cs
+++ b/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/ForRuntime/MotionDataRecorderCSV.cs
@@ -85,6 +85,7 @@ namespace Entum
 #endif
 
             RecordedTime = 0f;
+            StartTime = Time.time;
             FrameIndex = 0;
         }
     }

--- a/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/MotionDataRecorder.cs
+++ b/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/MotionDataRecorder.cs
@@ -56,6 +56,9 @@ namespace Entum
         public Action OnRecordStart;
         public Action OnRecordEnd;
 
+        [Tooltip("記録するFPS。0で制限しない。UpdateのFPSは超えられません。")]
+        public float TargetFPS = 60.0f;
+
 
         // Use this for initialization
         private void Awake()
@@ -93,6 +96,28 @@ namespace Entum
 
 
             RecordedTime = Time.time - StartTime;
+
+            if (TargetFPS != 0.0f)
+            {
+                var nextTime = (1.0f * (FrameIndex + 1)) / TargetFPS;
+                if (nextTime > RecordedTime)
+                {
+                    return;
+                }
+                if (FrameIndex % TargetFPS == 0)
+                {
+                    print("Motion_FPS=" + 1 / (RecordedTime / FrameIndex));
+                }
+            }
+            else
+            {
+                if (Time.frameCount % Application.targetFrameRate == 0)
+                {
+                    print("Motion_FPS=" + 1 / Time.deltaTime);
+                }
+            }
+
+
             //現在のフレームのHumanoidの姿勢を取得
             _poseHandler.GetHumanPose(ref _currentPose);
             //posesに取得した姿勢を書き込む

--- a/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/MotionDataRecorder.cs
+++ b/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/MotionDataRecorder.cs
@@ -49,6 +49,7 @@ namespace Entum
 
         protected HumanoidPoses Poses;
         protected float RecordedTime;
+        protected float StartTime;
 
         private HumanPose _currentPose;
         private HumanPoseHandler _poseHandler;
@@ -91,7 +92,7 @@ namespace Entum
             }
 
 
-            RecordedTime += Time.deltaTime;
+            RecordedTime = Time.time - StartTime;
             //現在のフレームのHumanoidの姿勢を取得
             _poseHandler.GetHumanPose(ref _currentPose);
             //posesに取得した姿勢を書き込む
@@ -163,6 +164,7 @@ namespace Entum
             OnRecordEnd += WriteAnimationFile;
             _recording = true;
             RecordedTime = 0f;
+            StartTime = Time.time;
             FrameIndex = 0;
         }
 
@@ -216,7 +218,7 @@ namespace Entum
 
             AssetDatabase.CreateAsset(Poses, uniqueAssetPath);
             AssetDatabase.Refresh();
-
+            StartTime = Time.time;
             RecordedTime = 0f;
             FrameIndex = 0;
 #endif


### PR DESCRIPTION
・表情の全フレームにキーを打たずにキーの設定を変更して必要なキーのみになるように修正
　 d58d7795f7a35087b4ac5ac625f9293819fe9224 への対策です

・開始時間と現在時刻でキーの時刻を計算して処理落ち時にずれないように修正
　音声と同時に10分程度録画した際にモーションと音声の記録時間にズレが発生したため変更しました

・記録時のFPS設定追加
　Updateの間隔で記録すると設定によってはキー数が大量になる為間引いて記録できるようにしました。

コミットが3つになっていますがよろしくお願いします。
実際の動作テストと、複数ユーザーから使用に問題ない報告を頂いております。